### PR TITLE
FYP-40: [BUG] Guess, clear and skip buttons do not work on touchscreen devices

### DIFF
--- a/components/DoodleCanvas.tsx
+++ b/components/DoodleCanvas.tsx
@@ -55,8 +55,28 @@ export default function DoodleCanvas({
           p.rect(1, 1, 278, 278);
         };
 
-        p.touchStarted = () => false;
-        p.touchMoved = () => false;
+        p.touchStarted = (event: any) => {
+          // Only prevent default if touch is inside canvas
+          if (
+            event &&
+            event.target &&
+            event.target.nodeName === "CANVAS"
+          ) {
+            return false;
+          }
+          // Allow default for touches outside canvas (e.g., buttons)
+          return true;
+        };
+        p.touchMoved = (event: any) => {
+          if (
+            event &&
+            event.target &&
+            event.target.nodeName === "CANVAS"
+          ) {
+            return false;
+          }
+          return true;
+        };
       };
 
       p5Instance = new window.p5(sketch);

--- a/components/DoodleCanvasTest.tsx
+++ b/components/DoodleCanvasTest.tsx
@@ -40,12 +40,26 @@ export default function DoodleCanvas({
           }
         };
 
-        // Prevent scrolling while drawing
-        p.touchStarted = () => {
-          return false;
+        // Prevent scrolling while drawing, but allow button touches
+        p.touchStarted = (event: any) => {
+          if (
+            event &&
+            event.target &&
+            event.target.nodeName === "CANVAS"
+          ) {
+            return false;
+          }
+          return true;
         };
-        p.touchMoved = () => {
-          return false;
+        p.touchMoved = (event: any) => {
+          if (
+            event &&
+            event.target &&
+            event.target.nodeName === "CANVAS"
+          ) {
+            return false;
+          }
+          return true;
         };
       };
 
@@ -118,12 +132,14 @@ export default function DoodleCanvas({
       <button
         onClick={handleGuess}
         className="bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600 transition-all mb-2"
+        type="button"
       >
         Guess
       </button>
       <button
         id="clear-button"
         className="bg-green-500 text-white py-2 px-4 rounded-lg hover:bg-green-600 transition-all"
+        type="button"
       >
         Clear Canvas
       </button>

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  allowedDevOrigins: [
+    'local-origin.dev',
+    '*.local-origin.dev',
+    'http://10.66.136.103:3000', // Add your local IP here
+    'http://localhost:3000',     // Optional: allow localhost too
+  ],
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start"
   },


### PR DESCRIPTION
1. Allow localhost on tablet and mobile
2. add --turbopack in package.jsos
3. Allow click/tap on buttons for "clear, skip and guess" when using touchscreen devices.