### PR TITLE
FYP-50: [BUG] Add back navigation functionality to DoodleCanvas and DoodlePage

### DIFF
--- a/app/menu/doodle/page.tsx
+++ b/app/menu/doodle/page.tsx
@@ -59,6 +59,16 @@ export default function DoodlePage() {
     setGuessAttempted(false);
   };
 
+  // Add back handler to go to previous word in sequence, looping to last if at first
+  const handleBack = () => {
+    setCurrentWordIndex((prevIndex) =>
+      prevIndex === 0 ? vocabularies.length - 1 : prevIndex - 1
+    );
+    setGuess(null);
+    setTopGuesses(null);
+    setGuessAttempted(false);
+  };
+
   const handleNext = () => {
     setShowSuccess(false);
     setSuccessInfo(null);
@@ -147,6 +157,7 @@ export default function DoodlePage() {
                 onSuccess={handleSuccess}
                 onGuess={handleGuess}
                 onSkip={handleSkip}
+                onBack={handleBack}
                 vocabularies={vocabularies.map((v) => v.name)}
                 onTopGuesses={handleTopGuesses}
               />

--- a/components/DoodleCanvasTest.tsx
+++ b/components/DoodleCanvasTest.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useRef } from "react";
 import { MdSkipNext } from "react-icons/md";
 import { RxEraser } from "react-icons/rx";
+import { IoMdSkipBackward } from "react-icons/io";
 
 export default function DoodleCanvas({
   targetWord,
   onSuccess,
   onGuess,
   onSkip,
+  onBack, // <-- make sure this is here
   vocabularies = [],
   onTopGuesses,
 }: {
@@ -16,6 +18,7 @@ export default function DoodleCanvas({
   onSuccess: (label: string, confidence: number) => void;
   onGuess: (label: string, confidence: number) => void;
   onSkip?: () => void;
+  onBack?: () => void; // <-- make sure this is here
   vocabularies?: string[];
   onTopGuesses?: (guesses: { label: string; confidence: number }[]) => void;
 }) {
@@ -205,7 +208,7 @@ export default function DoodleCanvas({
         >
           {/* The canvas will be appended here */}
         </div>
-        {/* Skip and Clear Canvas vertically on the right */}
+        {/* Skip, Erase, and Back vertically on the right */}
         <div className="flex flex-col space-y-2 ml-2">
           {onSkip && (
             <button
@@ -215,6 +218,16 @@ export default function DoodleCanvas({
               aria-label="Skip"
             >
               <MdSkipNext size={24} />
+            </button>
+          )}
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="bg-gray-200 text-gray-700 p-2 rounded-lg hover:bg-blue-200 transition-all flex items-center justify-center"
+              type="button"
+              aria-label="Back"
+            >
+              <IoMdSkipBackward  size={20} />
             </button>
           )}
           <button


### PR DESCRIPTION
Reintroduce the ability to navigate to the previous word in the sequence within the DoodleCanvas and DoodlePage components. This enhances user experience by allowing backward navigation.